### PR TITLE
Fix inaccurate segment GAID validation pattern

### DIFF
--- a/R/Segment-methods.R
+++ b/R/Segment-methods.R
@@ -75,7 +75,7 @@ setMethod(
     .Object <- callNextMethod(.Object, ...)
     if (!missing(value)) {
       value <- sub(kGaPrefix, "gaid::", value)
-      if (!grepl("^gaid::\\-?[0-9A-Za-z]+$", value)) {
+      if (!grepl("^gaid::\\-?[0-9A-Za-z\\-_]+$", value)) {
         value <- paste("gaid", value, sep = "::")
       }
       .Object@.Data <- value

--- a/R/segment-classes.R
+++ b/R/segment-classes.R
@@ -175,7 +175,7 @@ setClass(
   "gaSegmentId",
   contains = "character",
   validity = function(object) {
-    pattern <- "^gaid::\\-?[0-9A-Za-z]+$"
+    pattern <- "^gaid::\\-?[0-9A-Za-z\\-_]+$"
     if (length(object) != 1L) {
       "gaSegmentId must be a character vector of length 1"
     } else if (!grepl(pattern = pattern, x = object@.Data)) {


### PR DESCRIPTION
Segments created in the native Google Analytics segment builder are automatically assigned GAIDs; these GAIDs are usually alphanumeric but I've noticed that underscores and dashes are beginning to be used as valid characters. However, these IDs will trigger a hard error: 

```
Error in validObject(.Object) :
  invalid class "gaSegmentId" object: gaSegmentId must match the regular expression ^gaid::\-?[0-9A-Za-z]+$
```

I've amended the regex pattern used to validate the GAIDs to not fail on dashes or underscores.

![Image 2021-09-28 at 1 01 31 PM](https://user-images.githubusercontent.com/2652210/135141128-0e452572-a00a-43cd-854c-91b23c1d3e52.jpg)
